### PR TITLE
Improve frontend with shadcn components

### DIFF
--- a/frontend/src/components/project-list.tsx
+++ b/frontend/src/components/project-list.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Project } from '@/types';
 import { apiClient } from '@/lib/api';
 import { Trash2, ExternalLink, Clock, CheckCircle, XCircle } from 'lucide-react';
@@ -72,7 +73,21 @@ export function ProjectList({ refreshTrigger }: ProjectListProps) {
   };
 
   if (loading) {
-    return <div className="text-center py-8 text-gray-600 dark:text-gray-300">Loading projects...</div>;
+    return (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <Skeleton className="h-4 w-1/2" />
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-full" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
   }
 
   if (error) {

--- a/frontend/src/components/template-list.tsx
+++ b/frontend/src/components/template-list.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
 import { Template } from '@/types';
 import { apiClient } from '@/lib/api';
@@ -47,7 +48,21 @@ export function TemplateList({ onEdit, refreshTrigger }: TemplateListProps) {
   };
 
   if (loading) {
-    return <div className="text-center py-8 text-gray-600 dark:text-gray-300">Loading templates...</div>;
+    return (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <Skeleton className="h-4 w-1/2" />
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-full" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
   }
 
   if (error) {

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+import React from "react";
+
+export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      className={cn(
+        "animate-pulse rounded-md bg-muted",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+Skeleton.displayName = "Skeleton";


### PR DESCRIPTION
## Summary
- add `Skeleton` component to shadcn `ui`
- show skeleton cards while templates and projects load

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884151e97bc8320b97bddb26444a285