### PR TITLE
Improve frontend with shadcn components

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply min-h-screen;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -27,30 +27,33 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-            <nav className="border-b bg-gray-50 dark:bg-gray-900 border-gray-200 dark:border-gray-700">
+          <div className="min-h-screen flex flex-col bg-gradient-to-br from-gray-50 to-white dark:from-gray-900 dark:to-gray-950 text-gray-900 dark:text-gray-100">
+            <nav className="border-b bg-gradient-to-r from-purple-600 to-blue-600 text-white shadow">
               <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                <div className="flex justify-between h-16">
-                  <div className="flex items-center">
-                    <Link href="/" className="text-xl font-bold">
-                      Template Manager
-                    </Link>
-                  </div>
-                  <div className="flex items-center space-x-4">
+                <div className="flex justify-between items-center h-16">
+                  <Link href="/" className="text-xl font-bold">
+                    Template Manager
+                  </Link>
+                  <div className="flex items-center gap-4">
                     <Link href="/templates">
-                      <Button variant="ghost">Templates</Button>
+                      <Button variant="link" className="text-white hover:text-gray-200">Templates</Button>
                     </Link>
                     <Link href="/projects">
-                      <Button variant="ghost">Projects</Button>
+                      <Button variant="link" className="text-white hover:text-gray-200">Projects</Button>
                     </Link>
                     <ThemeToggle />
                   </div>
                 </div>
               </div>
             </nav>
-            <main className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+            <main className="flex-1 max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
               {children}
             </main>
+            <footer className="border-t bg-gradient-to-r from-purple-600 to-blue-600 text-white">
+              <div className="max-w-7xl mx-auto px-4 py-4 text-center text-sm">
+                Built with Next.js and shadcn/ui
+              </div>
+            </footer>
           </div>
         </ThemeProvider>
       </body>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,18 +6,18 @@ import { FileText, FolderPlus, GitBranch } from 'lucide-react';
 export default function HomePage() {
   return (
     <div className="space-y-8">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">
+      <div className="text-center space-y-4">
+        <h1 className="text-5xl font-extrabold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">
           Template Manager
         </h1>
-        <p className="text-xl text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
-          Manage your project templates and create new projects with ease. 
+        <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+          Manage your project templates and create new projects with ease.
           Store your favorite repository templates and generate new projects instantly.
         </p>
       </div>
 
       <div className="grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
-        <Card className="hover:shadow-lg transition-shadow bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700">
+        <Card className="hover:shadow-lg transition-shadow bg-white/70 dark:bg-gray-800/50 backdrop-blur border-gray-200 dark:border-gray-700">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <FileText className="h-5 w-5" />
@@ -37,7 +37,7 @@ export default function HomePage() {
           </CardContent>
         </Card>
 
-        <Card className="hover:shadow-lg transition-shadow bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700">
+        <Card className="hover:shadow-lg transition-shadow bg-white/70 dark:bg-gray-800/50 backdrop-blur border-gray-200 dark:border-gray-700">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <FolderPlus className="h-5 w-5" />
@@ -58,7 +58,7 @@ export default function HomePage() {
         </Card>
       </div>
 
-      <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-6 max-w-4xl mx-auto border border-gray-200 dark:border-gray-700">
+      <div className="bg-white/70 dark:bg-gray-800/50 backdrop-blur rounded-lg p-6 max-w-4xl mx-auto border border-gray-200 dark:border-gray-700">
         <h2 className="text-2xl font-bold mb-4 flex items-center gap-2">
           <GitBranch className="h-6 w-6" />
           How it works

--- a/frontend/src/components/project-list.tsx
+++ b/frontend/src/components/project-list.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Project } from '@/types';
 import { apiClient } from '@/lib/api';
 import { Trash2, ExternalLink, Clock, CheckCircle, XCircle } from 'lucide-react';
@@ -72,7 +73,21 @@ export function ProjectList({ refreshTrigger }: ProjectListProps) {
   };
 
   if (loading) {
-    return <div className="text-center py-8 text-gray-600 dark:text-gray-300">Loading projects...</div>;
+    return (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <Skeleton className="h-4 w-1/2" />
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-full" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
   }
 
   if (error) {

--- a/frontend/src/components/template-list.tsx
+++ b/frontend/src/components/template-list.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
 import { Template } from '@/types';
 import { apiClient } from '@/lib/api';
@@ -47,7 +48,21 @@ export function TemplateList({ onEdit, refreshTrigger }: TemplateListProps) {
   };
 
   if (loading) {
-    return <div className="text-center py-8 text-gray-600 dark:text-gray-300">Loading templates...</div>;
+    return (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <Skeleton className="h-4 w-1/2" />
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-full" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
   }
 
   if (error) {

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+import React from "react";
+
+export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      className={cn(
+        "animate-pulse rounded-md bg-muted",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+Skeleton.displayName = "Skeleton";


### PR DESCRIPTION
## Summary
- add `Skeleton` component to shadcn `ui`
- show skeleton cards while templates and projects load
- update layout with gradient navigation bar and footer
- polish home page with colorful hero and glassy cards

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884151e97bc8320b97bddb26444a285