### PR TITLE
Add project log streaming with SSE

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -90,6 +90,7 @@ func main() {
 	projects.Post("/", projectHandler.CreateProject)
 	projects.Get("/", projectHandler.GetAllProjects)
 	projects.Get("/:id", projectHandler.GetProject)
+	projects.Get("/:id/logs", projectHandler.StreamLogs)
 	projects.Delete("/:id", projectHandler.DeleteProject)
 
 	// Health check

--- a/backend/internal/usecase/log_manager.go
+++ b/backend/internal/usecase/log_manager.go
@@ -1,0 +1,99 @@
+package usecase
+
+import (
+	"sync"
+)
+
+// LogManager stores logs per project and allows subscribers to receive updates.
+type LogManager struct {
+	mu      sync.Mutex
+	streams map[uint]*logStream
+}
+
+type logStream struct {
+	mu          sync.Mutex
+	logs        []string
+	subscribers []chan string
+	closed      bool
+}
+
+// NewLogManager creates a new LogManager.
+func NewLogManager() *LogManager {
+	return &LogManager{streams: make(map[uint]*logStream)}
+}
+
+func (m *LogManager) getStream(id uint) *logStream {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.streams[id]
+	if !ok {
+		s = &logStream{}
+		m.streams[id] = s
+	}
+	return s
+}
+
+// Append adds a message to the project log and broadcasts to subscribers.
+func (m *LogManager) Append(id uint, msg string) {
+	s := m.getStream(id)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.logs = append(s.logs, msg)
+	for _, sub := range s.subscribers {
+		select {
+		case sub <- msg:
+		default:
+		}
+	}
+}
+
+// Subscribe returns a channel that receives future log messages for the project.
+// Existing logs are sent immediately in a separate goroutine.
+func (m *LogManager) Subscribe(id uint) <-chan string {
+	s := m.getStream(id)
+	ch := make(chan string, 10)
+	s.mu.Lock()
+	if s.closed {
+		close(ch)
+		s.mu.Unlock()
+		return ch
+	}
+	s.subscribers = append(s.subscribers, ch)
+	logs := append([]string(nil), s.logs...)
+	s.mu.Unlock()
+	go func() {
+		for _, l := range logs {
+			ch <- l
+		}
+	}()
+	return ch
+}
+
+// Close marks the project log as closed and closes all subscriber channels.
+func (m *LogManager) Close(id uint) {
+	s := m.getStream(id)
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
+	subs := s.subscribers
+	s.subscribers = nil
+	s.mu.Unlock()
+	for _, ch := range subs {
+		close(ch)
+	}
+}
+
+// GetLogs returns a copy of all logs for the project.
+func (m *LogManager) GetLogs(id uint) []string {
+	s := m.getStream(id)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	logs := append([]string(nil), s.logs...)
+	return logs
+}

--- a/frontend/src/app/projects/[id]/page.tsx
+++ b/frontend/src/app/projects/[id]/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { apiClient } from "@/lib/api";
+import { Project } from "@/types";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+export default function ProjectDetailPage() {
+  const params = useParams();
+  const id = Number(params.id);
+  const [project, setProject] = useState<Project | null>(null);
+  const [logs, setLogs] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchProject = async () => {
+      try {
+        const data = await apiClient.getProject(id);
+        setProject(data);
+      } catch {
+        setError("Failed to fetch project");
+      }
+    };
+
+    fetchProject();
+    const es = apiClient.streamProjectLogs(id, (msg) => {
+      setLogs((prev) => [...prev, msg]);
+    });
+    return () => es.close();
+  }, [id]);
+
+  if (error) return <div className="text-red-600">{error}</div>;
+  if (!project) return <div>Loading...</div>;
+
+  return (
+    <div className="space-y-4">
+      <Link href="/projects" className="text-sm underline">
+        Back to projects
+      </Link>
+      <Card>
+        <CardHeader>
+          <CardTitle>{project.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Badge>{project.status}</Badge>
+            {project.git_url && (
+              <a
+                href={project.git_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                Repository
+              </a>
+            )}
+          </div>
+          <div className="text-sm">Template: {project.template?.name}</div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Logs</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <pre className="text-sm whitespace-pre-wrap">{logs.join("\n")}</pre>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/project-form.tsx
+++ b/frontend/src/components/project-form.tsx
@@ -1,13 +1,20 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { CreateProjectRequest, Template } from '@/types';
-import { apiClient } from '@/lib/api';
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CreateProjectRequest, Template } from "@/types";
+import { apiClient } from "@/lib/api";
 
 interface ProjectFormProps {
   onSuccess: () => void;
@@ -17,11 +24,12 @@ interface ProjectFormProps {
 export function ProjectForm({ onSuccess, onCancel }: ProjectFormProps) {
   const [templates, setTemplates] = useState<Template[]>([]);
   const [formData, setFormData] = useState<CreateProjectRequest>({
-    name: '',
+    name: "",
     template_id: 0,
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     const fetchTemplates = async () => {
@@ -29,7 +37,7 @@ export function ProjectForm({ onSuccess, onCancel }: ProjectFormProps) {
         const data = await apiClient.getTemplates();
         setTemplates(data || []);
       } catch {
-        setError('Failed to fetch templates');
+        setError("Failed to fetch templates");
       }
     };
 
@@ -42,17 +50,21 @@ export function ProjectForm({ onSuccess, onCancel }: ProjectFormProps) {
     setError(null);
 
     try {
-      await apiClient.createProject(formData);
+      const project = await apiClient.createProject(formData);
       onSuccess();
+      router.push(`/projects/${project.id}`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
+      setError(err instanceof Error ? err.message : "An error occurred");
     } finally {
       setLoading(false);
     }
   };
 
-  const handleChange = (field: keyof CreateProjectRequest, value: string | number) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
+  const handleChange = (
+    field: keyof CreateProjectRequest,
+    value: string | number,
+  ) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
   };
 
   return (
@@ -67,7 +79,7 @@ export function ProjectForm({ onSuccess, onCancel }: ProjectFormProps) {
             <Input
               id="name"
               value={formData.name}
-              onChange={(e) => handleChange('name', e.target.value)}
+              onChange={(e) => handleChange("name", e.target.value)}
               placeholder="my-awesome-project"
               required
             />
@@ -77,7 +89,9 @@ export function ProjectForm({ onSuccess, onCancel }: ProjectFormProps) {
             <Label htmlFor="template">Template</Label>
             <Select
               value={formData.template_id.toString()}
-              onValueChange={(value) => handleChange('template_id', parseInt(value))}
+              onValueChange={(value) =>
+                handleChange("template_id", parseInt(value))
+              }
             >
               <SelectTrigger>
                 <SelectValue placeholder="Select a template" />
@@ -93,12 +107,17 @@ export function ProjectForm({ onSuccess, onCancel }: ProjectFormProps) {
           </div>
 
           {error && (
-            <div className="text-red-600 dark:text-red-400 text-sm">{error}</div>
+            <div className="text-red-600 dark:text-red-400 text-sm">
+              {error}
+            </div>
           )}
 
           <div className="flex gap-2 pt-4">
-            <Button type="submit" disabled={loading || formData.template_id === 0}>
-              {loading ? 'Creating...' : 'Create Project'}
+            <Button
+              type="submit"
+              disabled={loading || formData.template_id === 0}
+            >
+              {loading ? "Creating..." : "Create Project"}
             </Button>
             <Button type="button" variant="outline" onClick={onCancel}>
               Cancel

--- a/frontend/src/components/project-list.tsx
+++ b/frontend/src/components/project-list.tsx
@@ -1,13 +1,20 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Project } from '@/types';
-import { apiClient } from '@/lib/api';
-import { Trash2, ExternalLink, Clock, CheckCircle, XCircle } from 'lucide-react';
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Project } from "@/types";
+import { apiClient } from "@/lib/api";
+import {
+  Trash2,
+  ExternalLink,
+  Clock,
+  CheckCircle,
+  XCircle,
+} from "lucide-react";
 
 interface ProjectListProps {
   refreshTrigger?: number;
@@ -25,7 +32,7 @@ export function ProjectList({ refreshTrigger }: ProjectListProps) {
       setProjects(data || []);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch projects');
+      setError(err instanceof Error ? err.message : "Failed to fetch projects");
     } finally {
       setLoading(false);
     }
@@ -36,23 +43,27 @@ export function ProjectList({ refreshTrigger }: ProjectListProps) {
   }, [refreshTrigger]);
 
   const handleDelete = async (id: number) => {
-    if (!confirm('Are you sure you want to delete this project?')) return;
+    if (!confirm("Are you sure you want to delete this project?")) return;
 
     try {
       await apiClient.deleteProject(id);
-      setProjects(prev => prev.filter(p => p.id !== id));
+      setProjects((prev) => prev.filter((p) => p.id !== id));
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete project');
+      setError(err instanceof Error ? err.message : "Failed to delete project");
     }
   };
 
   const getStatusIcon = (status: string) => {
     switch (status) {
-      case 'creating':
-        return <Clock className="h-4 w-4 text-yellow-600 dark:text-yellow-400" />;
-      case 'ready':
-        return <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />;
-      case 'error':
+      case "creating":
+        return (
+          <Clock className="h-4 w-4 text-yellow-600 dark:text-yellow-400" />
+        );
+      case "ready":
+        return (
+          <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
+        );
+      case "error":
         return <XCircle className="h-4 w-4 text-red-600 dark:text-red-400" />;
       default:
         return null;
@@ -61,14 +72,14 @@ export function ProjectList({ refreshTrigger }: ProjectListProps) {
 
   const getStatusVariant = (status: string) => {
     switch (status) {
-      case 'creating':
-        return 'secondary';
-      case 'ready':
-        return 'default';
-      case 'error':
-        return 'destructive';
+      case "creating":
+        return "secondary";
+      case "ready":
+        return "default";
+      case "error":
+        return "destructive";
       default:
-        return 'outline';
+        return "outline";
     }
   };
 
@@ -102,8 +113,12 @@ export function ProjectList({ refreshTrigger }: ProjectListProps) {
   if (projects.length === 0) {
     return (
       <div className="text-center py-8">
-        <p className="text-gray-600 dark:text-gray-300 mb-4">No projects found</p>
-        <p className="text-sm text-gray-500 dark:text-gray-400">Create your first project from a template</p>
+        <p className="text-gray-600 dark:text-gray-300 mb-4">
+          No projects found
+        </p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Create your first project from a template
+        </p>
       </div>
     );
   }
@@ -114,7 +129,14 @@ export function ProjectList({ refreshTrigger }: ProjectListProps) {
         <Card key={project.id} className="hover:shadow-lg transition-shadow">
           <CardHeader className="pb-3">
             <div className="flex items-start justify-between">
-              <CardTitle className="text-lg">{project.name}</CardTitle>
+              <CardTitle className="text-lg">
+                <Link
+                  href={`/projects/${project.id}`}
+                  className="hover:underline"
+                >
+                  {project.name}
+                </Link>
+              </CardTitle>
               <Button
                 size="sm"
                 variant="ghost"
@@ -135,9 +157,10 @@ export function ProjectList({ refreshTrigger }: ProjectListProps) {
 
             <div className="space-y-2">
               <div className="text-sm">
-                <span className="font-medium">Template:</span> {project.template?.name}
+                <span className="font-medium">Template:</span>{" "}
+                {project.template?.name}
               </div>
-              
+
               {project.git_url && (
                 <div className="flex items-center gap-2 text-sm">
                   <ExternalLink className="h-4 w-4" />
@@ -157,11 +180,12 @@ export function ProjectList({ refreshTrigger }: ProjectListProps) {
               {project.template?.language && (
                 <Badge variant="secondary">{project.template.language}</Badge>
               )}
-              {project.template?.tags && project.template.tags.split(',').map((tag, index) => (
-                <Badge key={index} variant="outline">
-                  {tag.trim()}
-                </Badge>
-              ))}
+              {project.template?.tags &&
+                project.template.tags.split(",").map((tag, index) => (
+                  <Badge key={index} variant="outline">
+                    {tag.trim()}
+                  </Badge>
+                ))}
             </div>
 
             <div className="text-xs text-gray-500 dark:text-gray-400">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,21 +1,32 @@
-import { Template, CreateTemplateRequest, Project, CreateProjectRequest } from '@/types';
+import {
+  Template,
+  CreateTemplateRequest,
+  Project,
+  CreateProjectRequest,
+} from "@/types";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080/api/v1';
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api/v1";
 
 class ApiClient {
-  private async request<T>(endpoint: string, options?: RequestInit): Promise<T> {
+  private async request<T>(
+    endpoint: string,
+    options?: RequestInit,
+  ): Promise<T> {
     const url = `${API_BASE_URL}${endpoint}`;
-    
+
     const response = await fetch(url, {
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         ...options?.headers,
       },
       ...options,
     });
 
     if (!response.ok) {
-      const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+      const error = await response
+        .json()
+        .catch(() => ({ error: "Unknown error" }));
       throw new Error(error.error || `HTTP ${response.status}`);
     }
 
@@ -24,7 +35,7 @@ class ApiClient {
 
   // Templates
   async getTemplates(): Promise<Template[]> {
-    return this.request<Template[]>('/templates');
+    return this.request<Template[]>("/templates");
   }
 
   async getTemplate(id: number): Promise<Template> {
@@ -32,28 +43,31 @@ class ApiClient {
   }
 
   async createTemplate(data: CreateTemplateRequest): Promise<Template> {
-    return this.request<Template>('/templates', {
-      method: 'POST',
+    return this.request<Template>("/templates", {
+      method: "POST",
       body: JSON.stringify(data),
     });
   }
 
-  async updateTemplate(id: number, data: Partial<CreateTemplateRequest>): Promise<Template> {
+  async updateTemplate(
+    id: number,
+    data: Partial<CreateTemplateRequest>,
+  ): Promise<Template> {
     return this.request<Template>(`/templates/${id}`, {
-      method: 'PUT',
+      method: "PUT",
       body: JSON.stringify(data),
     });
   }
 
   async deleteTemplate(id: number): Promise<void> {
     return this.request<void>(`/templates/${id}`, {
-      method: 'DELETE',
+      method: "DELETE",
     });
   }
 
   // Projects
   async getProjects(): Promise<Project[]> {
-    return this.request<Project[]>('/projects');
+    return this.request<Project[]>("/projects");
   }
 
   async getProject(id: number): Promise<Project> {
@@ -61,16 +75,25 @@ class ApiClient {
   }
 
   async createProject(data: CreateProjectRequest): Promise<Project> {
-    return this.request<Project>('/projects', {
-      method: 'POST',
+    return this.request<Project>("/projects", {
+      method: "POST",
       body: JSON.stringify(data),
     });
   }
 
   async deleteProject(id: number): Promise<void> {
     return this.request<void>(`/projects/${id}`, {
-      method: 'DELETE',
+      method: "DELETE",
     });
+  }
+
+  streamProjectLogs(id: number, onMessage: (msg: string) => void): EventSource {
+    const url = `${API_BASE_URL}/projects/${id}/logs`;
+    const ev = new EventSource(url);
+    ev.onmessage = (e) => {
+      onMessage(e.data);
+    };
+    return ev;
   }
 }
 


### PR DESCRIPTION
## Summary
- stream project creation logs using SSE
- provide log manager for storing per-project logs
- expose `/projects/:id/logs` endpoint
- redirect to project details page after creating project
- show project logs and status on new detail page
- link project name to detail page in project list

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `go vet ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_68841c34b5e88320a88047f5dc8e01c9